### PR TITLE
Use subscripting for generics.

### DIFF
--- a/docs/features/error-handling.rst
+++ b/docs/features/error-handling.rst
@@ -14,7 +14,7 @@ Whereas in many programming languages, such as Java, any value can be a
 ``Option`` type, which is a way of specifying that there may be either a value,
 or ``None``::
 
-    def f(x: Option<Text>) -> Text:
+    def f(x: Option[Text]) -> Text:
         match as:
             as Some(value):
                 return value

--- a/docs/features/interfaces.rst
+++ b/docs/features/interfaces.rst
@@ -13,7 +13,7 @@ Bagel doesn't have subclassing.
 First, we write our interface::
 
     interface type CacheClient:
-        def get(self, key: Bytes) -> Option<Bytes>
+        def get(self, key: Bytes) -> Option[Bytes]
         def set(self, key: Bytes, value: Bytes)
 
 This says that to implement the ``CacheClient`` interface, a class must define
@@ -37,7 +37,7 @@ To satisfy the interface, all we need to do is define a class with ``get`` and
 ``set`` methods with appropriate signatures::
 
     class type InMemoryCache:
-        def get(self, key: Bytes) -> Option<Bytes>:
+        def get(self, key: Bytes) -> Option[Bytes]:
             # ...
 
         def set(self, key: Bytes, value: Bytes):


### PR DESCRIPTION
The angle brackets syntax was originally suggested by @hynek and @glyph (IIRC), I had been using curly braces origianlly.

However a review of [Andreas Stefik and Susanna Siebert. 2013] suggests that subscripting is more readily understood by non-programmers.

(Full citation: Andreas Stefik and Susanna Siebert. 2013. An Empirical Investigation into Programming Language Syntax. ACM Transactions on Computing Education 13, 4, Article 19 (November 2013), 40 pages.)
